### PR TITLE
feature: prompt select_account

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@codetrix-studio/capacitor-google-auth",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@codetrix-studio/capacitor-google-auth",
-      "version": "3.2.1",
+      "version": "3.2.2",
       "license": "MIT",
       "devDependencies": {
         "@capacitor/android": "^4.0.1",
@@ -20,7 +20,7 @@
         "typescript": "^4.7.4"
       },
       "peerDependencies": {
-        "@capacitor/core": "^4.0.1"
+        "@capacitor/core": "^4"
       }
     },
     "node_modules/@capacitor/android": {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -81,6 +81,12 @@ export interface InitOptions extends Pick<GoogleAuthPluginOptions, 'scopes' | 'c
    * @since 3.1.0
    * */
   grantOfflineAccess: boolean;
+    /**
+   * Force user to choose which accounts it wishes to use
+   * @default false
+   * @since x.x.x
+   */
+    select_account?: boolean;
 }
 
 export interface GoogleAuthPlugin {

--- a/src/web.ts
+++ b/src/web.ts
@@ -38,6 +38,7 @@ export class GoogleAuthWeb extends WebPlugin implements GoogleAuthPlugin {
       clientId: '',
       scopes: [],
       grantOfflineAccess: false,
+      select_account: false
     }
   ) {
     if (typeof window === 'undefined') {
@@ -55,6 +56,7 @@ export class GoogleAuthWeb extends WebPlugin implements GoogleAuthPlugin {
       clientId,
       grantOfflineAccess: _options.grantOfflineAccess ?? false,
       scopes: _options.scopes || [],
+      select_account: _options.select_account ?? false,
     };
 
     this.gapiLoaded = new Promise((resolve) => {
@@ -88,10 +90,13 @@ export class GoogleAuthWeb extends WebPlugin implements GoogleAuthPlugin {
       try {
         let serverAuthCode: string;
         const needsOfflineAccess = this.options.grantOfflineAccess ?? false;
-
+        const promptSelectAccount = this.options.select_account ?? false;
+        
         if (needsOfflineAccess) {
           const offlineAccessResponse = await gapi.auth2.getAuthInstance().grantOfflineAccess();
           serverAuthCode = offlineAccessResponse.code;
+        } else if (promptSelectAccount) {
+          await gapi.auth2.getAuthInstance().signIn({ prompt: 'select_account' });
         } else {
           await gapi.auth2.getAuthInstance().signIn();
         }


### PR DESCRIPTION
 It's now possible, through an option: select_account: boolean, to prompt the modal where the users can choose which account they wish to use.